### PR TITLE
Delete version fixing of certifi.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ asn1crypto==0.24.0
 attrs==19.1.0
 backcall==0.1.0
 bleach==3.1.0
-certifi==2018.10.15
 cffi==1.11.5
 chardet==3.0.4
 cloudpickle==0.8.0


### PR DESCRIPTION
I've found docker building failing and reported at #2 

I removed the statement of version fixing for the `certifi` module and this made the building successful.